### PR TITLE
#4 feat login - 로그인 및 로그아웃 기능 추가

### DIFF
--- a/src/main/kotlin/com/teamsparta/jobtopia/domain/users/controller/UserController.kt
+++ b/src/main/kotlin/com/teamsparta/jobtopia/domain/users/controller/UserController.kt
@@ -5,6 +5,7 @@ import com.teamsparta.jobtopia.domain.users.dto.LoginResponse
 import com.teamsparta.jobtopia.domain.users.dto.SignUpRequest
 import com.teamsparta.jobtopia.domain.users.dto.UserDto
 import com.teamsparta.jobtopia.domain.users.service.UserService
+import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -34,4 +35,13 @@ class UserController(
             .body(userService.login(loginRequest))
 
     }
+
+    @PostMapping("/logout")
+    fun logout(request: HttpServletRequest): ResponseEntity<Unit> {
+        val token = request.getAttribute("accessToken") as String?
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(userService.logout(token!!))
+    }
+
 }

--- a/src/main/kotlin/com/teamsparta/jobtopia/domain/users/controller/UserController.kt
+++ b/src/main/kotlin/com/teamsparta/jobtopia/domain/users/controller/UserController.kt
@@ -1,5 +1,7 @@
 package com.teamsparta.jobtopia.domain.users.controller
 
+import com.teamsparta.jobtopia.domain.users.dto.LoginRequest
+import com.teamsparta.jobtopia.domain.users.dto.LoginResponse
 import com.teamsparta.jobtopia.domain.users.dto.SignUpRequest
 import com.teamsparta.jobtopia.domain.users.dto.UserDto
 import com.teamsparta.jobtopia.domain.users.service.UserService
@@ -25,4 +27,11 @@ class UserController(
             .body(userService.signUp(signUpRequest))
     }
 
+    @PostMapping("/login")
+    fun signIn(@RequestBody loginRequest: LoginRequest): ResponseEntity<LoginResponse> {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(userService.login(loginRequest))
+
+    }
 }

--- a/src/main/kotlin/com/teamsparta/jobtopia/domain/users/dto/LoginResponse.kt
+++ b/src/main/kotlin/com/teamsparta/jobtopia/domain/users/dto/LoginResponse.kt
@@ -2,4 +2,12 @@ package com.teamsparta.jobtopia.domain.users.dto
 
 data class LoginResponse(
     val accessToken: String
-)
+) {
+    companion object {
+        fun fromEntity(token: String): LoginResponse {
+            return LoginResponse(
+                accessToken = token
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/teamsparta/jobtopia/domain/users/service/UserService.kt
+++ b/src/main/kotlin/com/teamsparta/jobtopia/domain/users/service/UserService.kt
@@ -1,8 +1,11 @@
 package com.teamsparta.jobtopia.domain.users.service
 
+import com.teamsparta.jobtopia.domain.users.dto.LoginRequest
+import com.teamsparta.jobtopia.domain.users.dto.LoginResponse
 import com.teamsparta.jobtopia.domain.users.dto.SignUpRequest
 import com.teamsparta.jobtopia.domain.users.dto.UserDto
 
 interface UserService {
     fun signUp(request: SignUpRequest): UserDto
+    fun login(loginRequest: LoginRequest): LoginResponse
 }

--- a/src/main/kotlin/com/teamsparta/jobtopia/domain/users/service/UserService.kt
+++ b/src/main/kotlin/com/teamsparta/jobtopia/domain/users/service/UserService.kt
@@ -8,4 +8,5 @@ import com.teamsparta.jobtopia.domain.users.dto.UserDto
 interface UserService {
     fun signUp(request: SignUpRequest): UserDto
     fun login(loginRequest: LoginRequest): LoginResponse
+    fun logout(token: String)
 }

--- a/src/main/kotlin/com/teamsparta/jobtopia/domain/users/service/UserServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/jobtopia/domain/users/service/UserServiceImpl.kt
@@ -1,6 +1,9 @@
 package com.teamsparta.jobtopia.domain.users.service
 
 import com.teamsparta.jobtopia.domain.common.exception.InvalidCredentialException
+import com.teamsparta.jobtopia.domain.common.exception.ModelNotFoundException
+import com.teamsparta.jobtopia.domain.users.dto.LoginRequest
+import com.teamsparta.jobtopia.domain.users.dto.LoginResponse
 import com.teamsparta.jobtopia.domain.users.dto.SignUpRequest
 import com.teamsparta.jobtopia.domain.users.dto.UserDto
 import com.teamsparta.jobtopia.domain.users.model.Profile
@@ -29,6 +32,20 @@ class UserServiceImpl(
             )
         )
         return UserDto.fromEntity(user)
+    }
+
+    override fun login(loginRequest: LoginRequest): LoginResponse {
+        val user = userRepository.findByUserName(loginRequest.userName) ?: throw ModelNotFoundException("Users", null)
+
+        if (user.userName != loginRequest.userName || !passwordEncoder.matches(loginRequest.password, user.password)) {
+            throw InvalidCredentialException()
+        }
+        return LoginResponse.fromEntity(
+            jwtPlugin.generateAccessToken(
+                subject = user.id.toString(),
+                userName = user.userName,
+            )
+        )
     }
 
 }

--- a/src/main/kotlin/com/teamsparta/jobtopia/domain/users/service/UserServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/jobtopia/domain/users/service/UserServiceImpl.kt
@@ -12,6 +12,7 @@ import com.teamsparta.jobtopia.domain.users.repository.UserRepository
 import com.teamsparta.jobtopia.infra.security.jwt.JwtPlugin
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class UserServiceImpl(
@@ -19,6 +20,9 @@ class UserServiceImpl(
     private val passwordEncoder: PasswordEncoder,
     private val jwtPlugin: JwtPlugin
 ) : UserService {
+    private val tokenBlacklist = mutableSetOf<String>()
+
+    @Transactional
     override fun signUp(request: SignUpRequest): UserDto {
         if (userRepository.findByUserName(request.userName) != null) {
             throw InvalidCredentialException("Username already exists")
@@ -46,6 +50,14 @@ class UserServiceImpl(
                 userName = user.userName,
             )
         )
+    }
+
+    override fun logout(token: String) {
+        tokenBlacklist.add(token)
+    }
+
+    fun isTokenBlacklisted(token: String): Boolean {
+        return tokenBlacklist.contains(token)
     }
 
 }

--- a/src/main/kotlin/com/teamsparta/jobtopia/infra/security/CustomAuthenticationEntrypoint.kt
+++ b/src/main/kotlin/com/teamsparta/jobtopia/infra/security/CustomAuthenticationEntrypoint.kt
@@ -1,0 +1,28 @@
+package com.teamsparta.jobtopia.infra.security
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.teamsparta.jobtopia.domain.common.exception.dto.ErrorResponse
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.MediaType
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+
+@Component
+class CustomAuthenticationEntrypoint: AuthenticationEntryPoint {
+
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException
+    ) {
+        response.status = HttpServletResponse.SC_UNAUTHORIZED
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.characterEncoding = "UTF-8"
+
+        val objectMapper = ObjectMapper()
+        val jsonString = objectMapper.writeValueAsString(ErrorResponse("JWT verification failed"))
+        response.writer.write(jsonString)
+    }
+}

--- a/src/main/kotlin/com/teamsparta/jobtopia/infra/security/UserPrincipal.kt
+++ b/src/main/kotlin/com/teamsparta/jobtopia/infra/security/UserPrincipal.kt
@@ -1,0 +1,16 @@
+package com.teamsparta.jobtopia.infra.security
+
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+
+data class UserPrincipal(
+    val id: Long,
+    val userName: String,
+    val authorities: Collection<GrantedAuthority>
+) {
+    constructor(id: Long, userName: String, roles: Set<String>) : this(
+        id,
+        userName,
+        roles.map { SimpleGrantedAuthority("ROLE_$it") })
+
+}

--- a/src/main/kotlin/com/teamsparta/jobtopia/infra/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/teamsparta/jobtopia/infra/security/config/SecurityConfig.kt
@@ -6,22 +6,24 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 @Configuration
 @EnableWebSecurity
-class SecurityConfig (
-    private val jwtAuthenticationFilter: JwtAuthenticationFilter
-){
+class SecurityConfig(
+    private val jwtAuthenticationFilter: JwtAuthenticationFilter,
+    private val authenticationEntrypoint: AuthenticationEntryPoint
+) {
 
     @Bean
-    fun filterChain(http : HttpSecurity) : SecurityFilterChain {
+    fun filterChain(http: HttpSecurity): SecurityFilterChain {
         return http
-            .httpBasic{it.disable()}
-            .formLogin{it.disable()}
-            .csrf{it.disable()}
-            .authorizeHttpRequests{
+            .httpBasic { it.disable() }
+            .formLogin { it.disable() }
+            .csrf { it.disable() }
+            .authorizeHttpRequests {
                 it
                     .requestMatchers("/swagger-ui/**").permitAll()
                     .requestMatchers("/v3/api-docs/**").permitAll()
@@ -30,6 +32,9 @@ class SecurityConfig (
                     .anyRequest().authenticated()
             }
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
+            .exceptionHandling {
+                it.authenticationEntryPoint(authenticationEntrypoint)
+            }
             .build()
     }
 }

--- a/src/main/kotlin/com/teamsparta/jobtopia/infra/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/teamsparta/jobtopia/infra/security/config/SecurityConfig.kt
@@ -1,5 +1,6 @@
 package com.teamsparta.jobtopia.infra.security.config
 
+import com.teamsparta.jobtopia.infra.security.jwt.JwtAuthenticationFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
@@ -11,7 +12,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 class SecurityConfig (
-//    private val jwtAuthenticationFilter: JwtAuthenticationFilter
+    private val jwtAuthenticationFilter: JwtAuthenticationFilter
 ){
 
     @Bean
@@ -28,7 +29,7 @@ class SecurityConfig (
                     .requestMatchers(HttpMethod.POST, "/api/v1/login").permitAll()
                     .anyRequest().authenticated()
             }
-//            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
             .build()
     }
 }

--- a/src/main/kotlin/com/teamsparta/jobtopia/infra/security/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/teamsparta/jobtopia/infra/security/jwt/JwtAuthenticationFilter.kt
@@ -1,0 +1,56 @@
+package com.teamsparta.jobtopia.infra.security.jwt
+
+import com.teamsparta.jobtopia.infra.security.UserPrincipal
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpHeaders
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class JwtAuthenticationFilter(
+    private val jwtPlugin: JwtPlugin
+) : OncePerRequestFilter() {
+
+    companion object {
+        private val BEARER_PATTERN = Regex("^Bearer (.+?)$")
+    }
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val jwt = request.getBearerToken()
+
+        if (jwt != null) {
+            jwtPlugin.validateToken(jwt)
+                .onSuccess {
+                    val userId = it.payload.subject.toLong()
+                    val role = it.payload.get("role", String::class.java)
+                    val userName = it.payload.get("username", String::class.java)
+
+                    val principal = UserPrincipal(
+                        id = userId,
+                        userName = userName,
+                        roles = setOf(role)
+                    )
+                    val authentication = JwtAuthenticationToken(
+                        principal = principal,
+                        details = WebAuthenticationDetailsSource().buildDetails(request)
+                    )
+                    SecurityContextHolder.getContext().authentication = authentication
+                }
+        }
+
+        filterChain.doFilter(request, response)
+    }
+
+    private fun HttpServletRequest.getBearerToken(): String? {
+        val headerValue = this.getHeader(HttpHeaders.AUTHORIZATION) ?: return null
+        return BEARER_PATTERN.find(headerValue)?.groupValues?.get(1)
+    }
+}

--- a/src/main/kotlin/com/teamsparta/jobtopia/infra/security/jwt/JwtAuthenticationToken.kt
+++ b/src/main/kotlin/com/teamsparta/jobtopia/infra/security/jwt/JwtAuthenticationToken.kt
@@ -1,0 +1,26 @@
+package com.teamsparta.jobtopia.infra.security.jwt
+
+import com.teamsparta.jobtopia.infra.security.UserPrincipal
+import org.springframework.security.authentication.AbstractAuthenticationToken
+import org.springframework.security.web.authentication.WebAuthenticationDetails
+import java.io.Serializable
+
+class JwtAuthenticationToken(
+    private val principal: UserPrincipal,
+    details: WebAuthenticationDetails,
+) : AbstractAuthenticationToken(principal.authorities), Serializable {
+
+    init {
+        super.setAuthenticated(true)
+        super.setDetails(details)
+    }
+
+    override fun getPrincipal() = principal
+
+    override fun getCredentials() = null
+
+    override fun isAuthenticated(): Boolean {
+        return true
+    }
+
+}


### PR DESCRIPTION
* 로그인 시 access token 클라이언트에 전달
* 로그아웃 시 블랙리스트에 전달받은 access 토큰 저장. 이후 해당 토큰으로 API 요청 시 JwtAuthenticationFilter에서 필터링하도록 구현했습니다.