### PR TITLE
:bug: #38 - 게시글 조회 시 CommentDTO로 변환할 때 오버로드 함수 추가

### DIFF
--- a/src/main/kotlin/com/teamsparta/jobtopia/domain/comment/dto/CommentDTO.kt
+++ b/src/main/kotlin/com/teamsparta/jobtopia/domain/comment/dto/CommentDTO.kt
@@ -6,8 +6,8 @@ import com.teamsparta.jobtopia.domain.reaction.dto.ReactionResponse
 data class CommentDTO(
     val id: Long?,
     val content: String,
-    var like: Int,
-    var dislike: Int
+    var like: Int = 0,
+    var dislike: Int = 0
 ) {
     companion object {
         fun from(comment: Comment, reaction: ReactionResponse): CommentDTO {
@@ -16,6 +16,12 @@ data class CommentDTO(
                 content = comment.content,
                 like = reaction.like,
                 dislike = reaction.dislike
+            )
+        }
+        fun from(comment: Comment): CommentDTO {
+            return CommentDTO(
+                id = comment.id,
+                content = comment.content,
             )
         }
     }


### PR DESCRIPTION
* 댓글 로직 중 CommentDTO로 변환하는 과정에서 reaction 매개변수가 추가되어 버그가 발생했습니다.
* CommentDTO 변환 함수 오버로드하여 해결하였습니다.